### PR TITLE
[Frontend] Hotfix - Change firebase auth from naming export to default

### DIFF
--- a/src/config/firebase.js
+++ b/src/config/firebase.js
@@ -12,10 +12,11 @@ const firebaseConfig = {
 };
 
 const app = initializeApp(firebaseConfig);
-
-export const auth = getAuth(app);
+const auth = getAuth(app);
 
 export const googleAuthProvider = new GoogleAuthProvider();
 googleAuthProvider.setCustomParameters({
   prompt: "select_account",
 });
+
+export default auth;


### PR DESCRIPTION
## 칸반 링크
* [[Frontend] Hotfix - Change firebase auth from naming export to default](https://sangminiam.notion.site/Frontend-Hotfix-Change-firebase-auth-from-naming-export-to-default-88b2c46abae344e6bf493c8aa4663f5b)
  
## 카드에서 구현 혹은 해결하려는 내용
- Firebase 오류 on deployment

## 테스트 방법
- Null

## 기타 사항
* Null